### PR TITLE
Use merged twixt-options.

### DIFF
--- a/src/io/aviso/twixt/startup.clj
+++ b/src/io/aviso/twixt/startup.clj
@@ -47,7 +47,7 @@
      (->
        handler
        ring/wrap-with-twixt
-       (export/wrap-with-exporter (:exports twixt-options))
+       (export/wrap-with-exporter (:exports twixt-options'))
        te/wrap-with-exception-reporting
        compress/wrap-with-compression-analyzer
        (ring/wrap-with-twixt-setup twixt-options' asset-pipeline)))))


### PR DESCRIPTION
This fixes an issue where export options would be nil when passed to `export/wrap-with-exporter` causing an exception to be thrown.
